### PR TITLE
Fastfetch: upgrade to 1.8.0

### DIFF
--- a/packages/fastfetch/build.sh
+++ b/packages/fastfetch/build.sh
@@ -2,9 +2,10 @@ TERMUX_PKG_HOMEPAGE=https://github.com/LinusDierheimer/fastfetch
 TERMUX_PKG_DESCRIPTION="A neofetch-like tool for fetching system information and displaying them in a pretty way"
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION="1.7.5"
+TERMUX_PKG_VERSION="1.8.0"
 TERMUX_PKG_SRCURL=https://github.com/LinusDierheimer/fastfetch/archive/${TERMUX_PKG_VERSION}.tar.gz
-TERMUX_PKG_SHA256=e9807568c2c5a10240c635e1e9ad5dbe63326eb730ca3aac005e19d91d2cd1c5
+TERMUX_PKG_SHA256=63f1b10755f18bbcf7d8300ee3bb05cf9b16a8f8b8ffa304c92162eed747467d
+TERMUX_PKG_DEPENDS="vulkan-headers, vulkan-loader-android, freetype"
 TERMUX_PKG_AUTO_UPDATE=true
 
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="


### PR DESCRIPTION
`vulkan-headers` and `vulkan-loader-android` are build dependencies. They don't need to be installed when running fastfetch.